### PR TITLE
Clone and share improvements

### DIFF
--- a/nbexamples/handlers.py
+++ b/nbexamples/handlers.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess as sp
 import json
 import glob
+import itertools
 
 from tornado import web
 
@@ -24,6 +25,19 @@ class Examples(LoggingConfigurable):
 
     def _unreviewed_example_dir_default(self):
         return self.parent.notebook_dir
+
+    def make_unique_filename(self, abs_fn, insert='-Clone'):
+        path, filename = os.path.split(abs_fn)
+        basename, ext = os.path.splitext(filename)
+        for i in itertools.count():
+            insert_i = '{}{}'.format(insert, i)
+            name = '{basename}{suffix}{ext}'.format(basename=basename,
+                                                    suffix=insert_i,
+                                                    ext=ext)
+            new_abs_fn = os.path.join(path, name)
+            if not os.path.exists(new_abs_fn):
+                break
+        return new_abs_fn
 
     def list_examples(self):
         categories = ['reviewed', 'unreviewed']
@@ -45,6 +59,9 @@ class Examples(LoggingConfigurable):
         abs_dest = os.path.join(self.parent.notebook_dir, dest)
         if not abs_dest.endswith('.ipynb'):
             abs_dest += '.ipynb'
+        # Give the target a unique suffix to avoid overwriting anything
+        if os.path.exists(abs_dest):
+            abs_dest = self.make_unique_filename(abs_dest)
         # Make a copy of the example notebook, stripping output.
         p = sp.Popen(['jupyter', 'nbconvert', example_id,
                       '--Exporter.preprocessors=["nbexamples.strip_output.StripOutput"]',
@@ -55,9 +72,11 @@ class Examples(LoggingConfigurable):
         if retcode != 0:
             raise RuntimeError('jupyter nbconvert exited with error {}'.format(
                                err))
+        # Return the possibly suffixed filename
+        return os.path.split(abs_dest)[1]
 
     def submit_example(self, user_filepath):
-        # Make a copy of the example notebook.
+        # Make a copy of the example notebook
         src = os.path.join(self.parent.notebook_dir, user_filepath)
         filename = os.path.basename(user_filepath)
         dest = os.path.join(self.unreviewed_example_dir, filename)
@@ -103,10 +122,7 @@ class ExampleActionHandler(BaseExampleHandler):
             self.finish(self.manager.preview_example(example_id))
         elif action == 'fetch':
             dest = self.get_argument('dest')
-            self.manager.fetch_example(example_id, dest)
-            # nbconvert appends '.ipynb' if it isn't present
-            if not dest.endswith('.ipynb'):
-                dest += '.ipynb'
+            dest = self.manager.fetch_example(example_id, dest)
             self.redirect(ujoin(self.base_url, 'notebooks', dest))
         elif action == 'submit':
             dest = self.manager.submit_example(example_id)

--- a/nbexamples/handlers.py
+++ b/nbexamples/handlers.py
@@ -53,6 +53,7 @@ class Examples(LoggingConfigurable):
                 example['metadata'] = node.metadata
                 example['category'] = category
                 example['owned'] = os.stat(example['filepath']).st_uid == uid
+                example['basename'] = os.path.basename(example['filepath'])
             all_examples.extend(examples)
         return all_examples
 

--- a/nbexamples/static/examples.js
+++ b/nbexamples/static/examples.js
@@ -63,9 +63,13 @@ define([
         [this.reviewed_element, this.unreviewed_element].forEach(function(element) {
             element.on('click', '[data-filepath]', function(evt) {
                 var filepath = $(evt.target).data('filepath');
+                var basename = $(evt.target).data('basename');
                 that.dialog_element
                     .find('[name="example_id"]')
                     .attr('value', filepath);
+                that.dialog_element
+                    .find('[name="dest"]')
+                    .attr('value', basename);
                 that.dialog_element.modal('show');
             });
         });
@@ -166,6 +170,7 @@ define([
         btns.append($('<button/>')
             .addClass("btn btn-success btn-xs")
             .attr('data-filepath', this.data.filepath)
+            .attr('data-basename', this.data.basename)
             .text('Use'));
         row.append(btns);
         this.element.empty().append(row);


### PR DESCRIPTION
* Mimick how notebook server appends a unique suffix to copies on conflict
* Give better error messages when a user tries to share a notebook but a notebook with the same name is already shared by another user
* Fill the save copy text box with the filename of the example

Fixes #13